### PR TITLE
refactor: Date計算をTemporal APIに置き換え

### DIFF
--- a/app/routes/$counter.tsx
+++ b/app/routes/$counter.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "hono/jsx";
-import { getTimeUntilBirthday } from "../utils";
+import { Temporal } from "temporal-polyfill-lite";
+import { getTimeUntilBirthday, TIME_ZONE } from "../utils";
 
 type InitialTime = {
   days: number;
@@ -24,11 +25,9 @@ export default function Counter(props: InitialTime) {
     };
   }, []);
 
-  const isBirthday =
-    new Date()
-      .toLocaleString("ja-JP", { timeZone: "Asia/Tokyo" })
-      .slice(5, 10) === "10/30";
-  const getAge = new Date().getFullYear() - 1989;
+  const today = Temporal.Now.plainDateISO(TIME_ZONE);
+  const isBirthday = today.month === 10 && today.day === 30;
+  const getAge = today.year - 1989;
 
   return (
     <>

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,3 +1,5 @@
+import { Temporal } from "temporal-polyfill-lite";
+
 type TimeUntilBirthday = {
   days: number;
   hours: number;
@@ -5,26 +7,26 @@ type TimeUntilBirthday = {
   seconds: number;
 };
 
+export const TIME_ZONE = "Asia/Tokyo";
+
+const BIRTHDAY = { month: 10, day: 30 };
+
 /**
- * 次の誕生日までの秒数とその内訳を計算する関数
+ * 次の誕生日(日本時間10月30日 0時)までの残り時間を計算する関数
  * @returns 日、時間、分、秒のオブジェクト
  */
 export const getTimeUntilBirthday = (): TimeUntilBirthday => {
-  const now = new Date();
-  const currentYear = now.getFullYear();
-  let nextBirthday = new Date(`${currentYear}-10-30`);
+  const now = Temporal.Now.zonedDateTimeISO(TIME_ZONE);
+  let nextBirthday = now.with(BIRTHDAY).startOfDay();
 
-  if (now > nextBirthday) {
-    nextBirthday = new Date(`${currentYear + 1}-10-30`);
+  if (Temporal.ZonedDateTime.compare(now, nextBirthday) > 0) {
+    nextBirthday = nextBirthday.add({ years: 1 });
   }
 
-  const diffInSeconds = Math.floor((Number(nextBirthday) - Number(now)) / 1000);
-  const days = Math.floor(diffInSeconds / (60 * 60 * 24));
-  // hoursを日本時間の24時間計算になるようにする
-  let hours = Math.floor((diffInSeconds / (60 * 60)) % 24) - 9;
-  hours < 0 ? (hours = hours + 24) : hours;
-  const minutes = Math.floor((diffInSeconds / 60) % 60);
-  const seconds = diffInSeconds % 60;
+  const { days, hours, minutes, seconds } = now.until(nextBirthday, {
+    largestUnit: "day",
+    smallestUnit: "second"
+  });
 
   return { days, hours, minutes, seconds };
 };
@@ -42,8 +44,8 @@ if (import.meta.vitest) {
     });
 
     it("誕生日前の場合、正しい残り時間を計算する", () => {
-      // 2024年4月1日 12:00:00 に設定 (誕生日10月30日の前)
-      const mockDate = new Date(2024, 3, 1, 12, 0, 0);
+      // 日本時間 2024年4月1日 12:00:00 に設定 (誕生日10月30日の前)
+      const mockDate = new Date("2024-04-01T12:00:00+09:00");
 
       vi.setSystemTime(mockDate);
 
@@ -57,8 +59,8 @@ if (import.meta.vitest) {
     });
 
     it("誕生日当日の場合、正しい残り時間を計算する", () => {
-      // 2024年10月30日 00:00:00 に設定 (誕生日当日の朝)
-      const mockDate = new Date(2024, 9, 30, 0, 0, 0);
+      // 日本時間 2024年10月30日 00:00:00 に設定 (誕生日当日の朝)
+      const mockDate = new Date("2024-10-30T00:00:00+09:00");
       vi.setSystemTime(mockDate);
 
       const result = getTimeUntilBirthday();
@@ -71,8 +73,8 @@ if (import.meta.vitest) {
     });
 
     it("誕生日後の場合、翌年の誕生日までの時間を計算する", () => {
-      // 2024年10月31日 12:00:00 に設定 (誕生日10月30日の後)
-      const mockDate = new Date(2024, 9, 31, 12, 0, 0);
+      // 日本時間 2024年10月31日 12:00:00 に設定 (誕生日10月30日の後)
+      const mockDate = new Date("2024-10-31T12:00:00+09:00");
       vi.setSystemTime(mockDate);
 
       const result = getTimeUntilBirthday();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "hono": "^4.2.3",
-        "honox": "^0.1.9"
+        "honox": "^0.1.9",
+        "temporal-polyfill-lite": "0.4.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.16",
@@ -239,9 +240,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -259,9 +257,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -279,9 +274,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -299,9 +291,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -378,6 +367,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -394,6 +384,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -410,6 +401,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -426,6 +418,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -442,6 +435,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -455,7 +449,7 @@
       "version": "4.20260610.1",
       "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260610.1.tgz",
       "integrity": "sha512-Mk/f3lUygeIHzQ4HnJjU/JvGg/kllgp9gISty9nylHE/2M2MFeKO+hgAKSgiPpmwUbuhewdYGgqFGgT/ADK0/g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -509,6 +503,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -533,6 +528,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -549,6 +545,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -565,6 +562,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -581,6 +579,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -597,6 +596,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -613,6 +613,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -629,6 +630,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -645,6 +647,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -661,6 +664,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -677,6 +681,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,6 +698,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -709,6 +715,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -725,6 +732,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,6 +749,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,6 +766,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -773,6 +783,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -789,6 +800,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -805,6 +817,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -821,6 +834,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,6 +851,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -853,6 +868,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -869,6 +885,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -885,6 +902,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,6 +919,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,6 +936,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -933,6 +953,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1014,6 +1035,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1036,6 +1058,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1058,6 +1081,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1074,6 +1098,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1090,6 +1115,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1106,6 +1132,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1122,6 +1149,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1138,6 +1166,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1154,6 +1183,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1170,6 +1200,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1186,6 +1217,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1202,6 +1234,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1218,6 +1251,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1240,6 +1274,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1262,6 +1297,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1284,6 +1320,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1306,6 +1343,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1328,6 +1366,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1350,6 +1389,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1372,6 +1412,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1394,6 +1435,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
@@ -1413,6 +1455,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1432,6 +1475,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1451,6 +1495,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1707,9 +1752,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1727,9 +1769,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1747,9 +1786,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1767,9 +1803,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1787,9 +1820,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1807,9 +1837,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2069,9 +2096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2089,9 +2113,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2109,9 +2130,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2129,9 +2147,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3046,6 +3061,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -3972,6 +3988,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/temporal-polyfill-lite": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill-lite/-/temporal-polyfill-lite-0.4.0.tgz",
+      "integrity": "sha512-Bwx9kt1xDsMqOKsRuprWwMaO+pOLa24/k1+CAcbSeFQkURnoPZibg4shuTPEDsqiinCefHiiN2jf4bnOXwNbbQ==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -4075,6 +4097,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "hono": "^4.2.3",
-    "honox": "^0.1.9"
+    "honox": "^0.1.9",
+    "temporal-polyfill-lite": "0.4.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.16",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
+    "skipLibCheck": true,
     "lib": [
       "ESNext"
     ],


### PR DESCRIPTION
## 概要

カウントダウンのDate計算をすべて [temporal-polyfill-lite](https://www.npmjs.com/package/temporal-polyfill-lite) の Temporal API に置き換えました。

## 変更内容

- **`app/utils.ts`**: `getTimeUntilBirthday` を `Temporal.Now.zonedDateTimeISO("Asia/Tokyo")` ベースに書き換え。誕生日(JST 10月30日 0時)までの残り時間を `now.until()` で算出し、UTC差分から hours を `-9` 補正するハックを撤廃
- **`app/routes/$counter.tsx`**: `toLocaleString().slice()` による誕生日判定を `Temporal.PlainDate` の `month`/`day` 比較に、年齢計算も `today.year - 1989` に置き換え(Asia/Tokyo 基準に統一)
- **テスト**: モック時刻を `new Date(2024, 3, 1, ...)`(実行環境のTZ依存)から JST オフセット明示の ISO 文字列に変更し、TZ非依存化
- **`tsconfig.json`**: `skipLibCheck: true` を追加(hono / miniflare / 本ポリフィルの型定義による node_modules 内エラーを解消。`tsc --noEmit` がエラー0で通るように)

ポリフィルはグローバル汚染を避けるため ponyfill 形式(`import { Temporal } from "temporal-polyfill-lite"`)で利用しています。

## 挙動の変化

誕生日当日の JST 0時〜9時の間、旧コードは当年の誕生日(UTC 0時 = JST 9時)へのカウントダウンを返していましたが、新コードは JST 0時を過ぎた時点で翌年分に切り替わります。当日は誕生日メッセージが表示されカウントダウン自体が非表示になるため、表示上の差はありません。

## 検証

- `npm test`: 3件パス
- `npm run biome:ci`: パス
- `npm run build`: クライアント/サーバーともビルド成功
- `npx tsc --noEmit`: エラー0

🤖 Generated with [Claude Code](https://claude.com/claude-code)