### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single-product repo: a birthday countdown web app built with **HonoX** (Hono + file-based routing, SSR + client islands), **Tailwind CSS v4**, and the TC39 **Temporal** API, targeting **Cloudflare Workers**. There is no backend/database/auth — all countdown data is computed from the system clock, so no environment variables or secrets are needed for local development.
+
+Standard commands live in `package.json` scripts; use those rather than duplicating them here:
+
+- Dev server: `npm run dev` (Vite, serves at `http://localhost:5173/`). This is the single service needed to run/test the product end to end.
+- Tests: `npm run test` (Vitest, in-source tests via `import.meta.vitest`, node environment).
+- Lint/format: `npm run biome:ci` (check only) or `npm run biome` (writes fixes).
+- Build: `npm run build` (client build then SSR build → `dist/`).
+- Worker emulation (optional): `npm run preview` (`wrangler dev`, needs `npm run build` first).
+- Deploy (optional, not for local dev): `npm run deploy` — requires Cloudflare credentials.
+
+Non-obvious notes:
+
+- The countdown target is fixed to Oct 30 (`Asia/Tokyo`); on non-birthday days the app shows a countdown, and on the birthday it switches to a celebration screen. To exercise the celebration branch without waiting, adjust the date logic in `app/utils.ts` locally (do not commit).
+- In-source Vitest tests are stripped from production builds via the `import.meta.vitest` define in both `vite.config.ts` and `vitest.config.ts`.
+- CI (`.github/workflows/biome.yml`) runs on Node 23.x, but the app runs fine on the Node 22.x provided by the VM (no `engines` constraint); no version manager switch is required.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this HonoX / Cloudflare Workers birthday countdown app and verifies it works end to end. Adds `AGENTS.md` with durable, non-obvious guidance for future cloud agents.

The update script is `npm ci` (dependency refresh only). No secrets or external services are required — all countdown data is computed from the system clock.

## Verification

All standard workflows were run successfully:

| Task | Command | Result |
|------|---------|--------|
| Install | `npm ci` | 200 packages installed |
| Lint | `npm run biome:ci` | Passed (9 files checked) |
| Test | `npm run test` | 4/4 tests passed (Vitest) |
| Build | `npm run build` | Client + SSR bundles built to `dist/` |
| Run | `npm run dev` | Serves at `http://localhost:5173/` |

End-to-end check: loaded the app in Chrome, confirmed SSR renders the countdown and the client island hydrates with a live per-second timer (seconds observed decreasing 28 → 18 → 08 → 03).

[birthday_countdown_live_timer.mp4](https://cursor.com/agents/bc-183f84ad-0f2f-4727-bdfa-c29083f06590/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbirthday_countdown_live_timer.mp4)

[Birthday countdown app running with live timer](https://cursor.com/agents/bc-183f84ad-0f2f-4727-bdfa-c29083f06590/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbirthday_countdown_screenshot.webp)

## Notes

- CI uses Node 23.x; the app runs fine on the VM's Node 22.x (no `engines` constraint).
- `AGENTS.md` was added under `## Cursor Cloud specific instructions` — please merge so future agents retain this context.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-183f84ad-0f2f-4727-bdfa-c29083f06590?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-183f84ad-0f2f-4727-bdfa-c29083f06590&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

